### PR TITLE
feat: rename `minimal` to `stripped` in `lineMode` for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Type: `String`
 Default: `'original'`
 
 The `lineMode` option specifies how the parsed line should be formatted. The following values are supported:
-- `'original'`: Keeps the line unchanged, including comments and whitespace. (Default)
-- `'minimal'`: Removes comments, trims leading and trailing whitespace, but preserves inner whitespace.
-- `'compact'`: Removes both comments and all whitespace.
+- `'original'`: Retains the line exactly as is, including comments and whitespace. (This is the default when `lineMode` is not specified.)
+- `'stripped'`: Removes comments, trims leading and trailing whitespace (spaces and tabs), but keeps the inner whitespace between code elements.
+- `'compact'`: Removes both comments and all whitespace characters.
 
 Example usage:
 
@@ -115,7 +115,7 @@ Example usage:
 parser.parseLine('G0 X0 Y0 ; comment', { lineMode: 'original' });
 // => { line: 'G0 X0 Y0 ; comment', words: [ [ 'G', 0 ], [ 'X', 0 ], [ 'Y', 0 ] ] }
 
-parser.parseLine('G0 X0 Y0 ; comment', { lineMode: 'minimal' });
+parser.parseLine('G0 X0 Y0 ; comment', { lineMode: 'stripped' });
 // => { line: 'G0 X0 Y0', words: [ [ 'G', 0 ], [ 'X', 0 ], [ 'Y', 0 ] ] }
 
 parser.parseLine('G0 X0 Y0 ; comment', { lineMode: 'compact' });

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -52,22 +52,22 @@ describe('Invalid G-code words', () => {
   });
 });
 
-describe('Using the `lineMode` option', () => {
-  it('should return the original line with comments and whitespace in original mode', () => {
+describe('The `lineMode` option', () => {
+  it('should retain the line exactly as is, including comments and whitespace for `lineMode="original"`', () => {
     const line = 'M6 (tool change;) T1 ; comment';
     const result = parseLine(line, { lineMode: 'original' });
     expect(result.line).toBe('M6 (tool change;) T1 ; comment');
     expect(result.words).toEqual([['M', 6], ['T', 1]]);
   });
 
-  it('should return the line without comments but with whitespace in minimal mode', () => {
+  it('should remove comments, trims leading and trailing whitespace (spaces and tabs), but keeps the inner whitespace between code elements for `lineMode="stripped"`', () => {
     const line = 'M6 (tool change;) T1 ; comment';
-    const result = parseLine(line, { lineMode: 'minimal' });
+    const result = parseLine(line, { lineMode: 'stripped' });
     expect(result.line).toBe('M6  T1');
     expect(result.words).toEqual([['M', 6], ['T', 1]]);
   });
 
-  it('should return the line without comments and whitespace in compact mode', () => {
+  it('should remove both comments and all whitespace characters for `lineMode="compact"`', () => {
     const line = 'M6 (tool change;) T1 ; comment';
     const result = parseLine(line, { lineMode: 'compact' });
     expect(result.line).toBe('M6T1');

--- a/src/index.js
+++ b/src/index.js
@@ -103,9 +103,9 @@ const parseLine = (() => {
     options.flatten = !!options?.flatten;
 
     const validLineModes = [
-      'original', // Keeps the line unchanged, including comments and whitespace. (Default)
-      'minimal',  // Removes comments, trims leading and trailing whitespace, but preserves inner whitespace.
-      'compact',  // Removes both comments and all whitespace.
+      'original', // Retains the line exactly as is, including comments and whitespace. (This is the default when `lineMode` is not specified.)
+      'stripped',  // Removes comments, trims leading and trailing whitespace (spaces and tabs), but keeps the inner whitespace between code elements.
+      'compact',  // Removes both comments and all whitespace characters.
     ];
     if (!validLineModes.includes(options?.lineMode)) {
       options.lineMode = validLineModes[0];
@@ -119,13 +119,13 @@ const parseLine = (() => {
     let ln; // Line number
     let cs; // Checksum
     const originalLine = line;
-    const [minimalLine, comments] = stripComments(line);
-    const compactLine = stripWhitespace(minimalLine);
+    const [strippedLine, comments] = stripComments(line);
+    const compactLine = stripWhitespace(strippedLine);
 
     if (options.lineMode === 'compact') {
       result.line = compactLine;
-    } else if (options.lineMode === 'minimal') {
-      result.line = minimalLine;
+    } else if (options.lineMode === 'stripped') {
+      result.line = strippedLine;
     } else {
       result.line = originalLine;
     }


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Renamed the `lineMode` option from `minimal` to `stripped` for better clarity across the codebase.
- Updated test cases in `index.test.js` to reflect the new `lineMode` naming and improved test descriptions.
- Modified the logic in `index.js` to use the new `stripped` naming and enhanced comments for clarity.
- Updated the README documentation to reflect the renaming and improved descriptions of the `lineMode` options.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.js</strong><dd><code>Update test cases for `lineMode` renaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/__tests__/index.test.js

<li>Updated test descriptions for clarity.<br> <li> Renamed <code>lineMode</code> option from <code>minimal</code> to <code>stripped</code>.<br> <li> Adjusted test cases to reflect the new <code>lineMode</code> naming.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/gcode-parser/pull/8/files#diff-cb42e3e1c929a555702a6bad604a72888fb9bb6492713e59583a02c5acf871c4">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Rename `lineMode` option and update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.js

<li>Renamed <code>lineMode</code> option from <code>minimal</code> to <code>stripped</code>.<br> <li> Updated logic to use <code>stripped</code> instead of <code>minimal</code>.<br> <li> Improved comments for <code>lineMode</code> options.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/gcode-parser/pull/8/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for `lineMode` renaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated documentation to reflect <code>lineMode</code> renaming.<br> <li> Improved descriptions for <code>lineMode</code> options.<br> <li> Changed example usage to use <code>stripped</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/gcode-parser/pull/8/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information