### PR TITLE
feat: exports `stripComments`

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -6,7 +6,8 @@ import {
   parseString,
   parseStringSync,
   parseFile,
-  parseFileSync
+  parseFileSync,
+  stripComments,
 } from '..';
 
 describe('Pass a null value as the first argument', () => {
@@ -148,6 +149,7 @@ describe('Commands', () => {
 describe('Stripping comments', () => {
   it('should correctly parse a semicolon comment before parentheses', () => {
     const line = 'M6 ; comment (tool change) T1';
+    expect(stripComments(line)).toBe('M6');
     const data = parseLine(line, { lineMode: 'stripped' });
     expect(data.line).toBe('M6');
     expect(data.comments).toEqual([
@@ -157,6 +159,7 @@ describe('Stripping comments', () => {
 
   it('should correctly parse nested parentheses containing a semicolon', () => {
     const line = 'M6 (outer (inner;)) T1 ; comment';
+    expect(stripComments(line)).toBe('M6  T1');
     const data = parseLine(line, { lineMode: 'stripped' });
     expect(data.line).toBe('M6  T1');
     expect(data.comments).toEqual([
@@ -167,6 +170,7 @@ describe('Stripping comments', () => {
 
   it('should correctly parse multiple comments in a line', () => {
     const line = 'M6 (first comment) T1 ; second comment';
+    expect(stripComments(line)).toBe('M6  T1');
     const data = parseLine(line, { lineMode: 'stripped' });
     expect(data.line).toBe('M6  T1');
     expect(data.comments).toEqual([


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Implemented the `stripComments` function to strip comments from G-code lines, enhancing the parsing capabilities.
- Refactored the comment stripping logic into a new function `stripCommentsEx` for better modularity.
- Added and exported the `stripComments` function for external use.
- Added comprehensive tests for the `stripComments` function to ensure correct parsing of comments in various scenarios.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.js</strong><dd><code>Add tests for `stripComments` function in G-code parsing</code>&nbsp; </dd></summary>
<hr>

src/__tests__/index.test.js

<li>Added tests for <code>stripComments</code> function.<br> <li> Verified correct parsing of comments in G-code lines.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/gcode-parser/pull/10/files#diff-cb42e3e1c929a555702a6bad604a72888fb9bb6492713e59583a02c5acf871c4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Implement and export `stripComments` function for G-code</code>&nbsp; </dd></summary>
<hr>

src/index.js

<li>Implemented <code>stripComments</code> function to remove comments from G-code <br>lines.<br> <li> Refactored comment stripping logic into <code>stripCommentsEx</code>.<br> <li> Exported <code>stripComments</code> for external use.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/gcode-parser/pull/10/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556">+76/-76</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information